### PR TITLE
no default css

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -108,12 +108,7 @@ bool QueueCEFTask(std::function<void()> task)
 
 /* ========================================================================= */
 
-static const char *default_css = "\
-body { \
-background-color: rgba(0, 0, 0, 0); \
-margin: 0px auto; \
-overflow: hidden; \
-}";
+static const char *default_css = "";
 
 static void browser_source_get_defaults(obs_data_t *settings)
 {


### PR DESCRIPTION
The custom CSS causes you not to be able to scroll certain websites and causes transparency/discoloration effects on random websites.