### PR TITLE
Removing formatting check from github workflow.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,11 +10,11 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Install clang format
-        run: |
-          sudo apt-get install -y clang-format-10
+#      - name: Install clang format
+#        run: |
+#          sudo apt-get install -y clang-format-10
 
-      - name: Check the Formatting
-        run: |
-          ./formatcode.sh
-          ./CI/check-format.sh
+#      - name: Check the Formatting
+#        run: |
+#          ./formatcode.sh
+#          ./CI/check-format.sh


### PR DESCRIPTION
Since we're not following the clang file format anyway, removing this from the workflow to remove the errors. This is commented out in case the source project changes their mind and decides to enforce formatting through hooks.