### PR TITLE
set browser-source-path for macos

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -401,14 +401,18 @@ static void BrowserInit(obs_data_t *settings_obs)
 		std::string browserSourcePath = binPath;
 		binPath += "/Frameworks/Chromium Embedded Framework.framework";
 		CefString(&settings.framework_dir_path) = binPath;
-		
+
 		// Set the browser-source-path. Streamlabs desktop (if not run within an app)
 		// will not spin up all the helper apps but at least we will not crash.
 		// Streamlabs desktop.app and OBS.app backend will work properly with browser
 		// sources because they can both spin up the helper processes.
-		browserSourcePath += "/Frameworks/obs64 Helper.app/Contents/MacOS/obs64 Helper";
-		CefString(&settings.browser_subprocess_path) = browserSourcePath;
-		blog(LOG_INFO, "Set browser_subprocess_path for obs64 (app bundle): [%s]", browserSourcePath.c_str());
+		browserSourcePath +=
+			"/Frameworks/obs64 Helper.app/Contents/MacOS/obs64 Helper";
+		CefString(&settings.browser_subprocess_path) =
+			browserSourcePath;
+		blog(LOG_INFO,
+		     "Set browser_subprocess_path for obs64 (app bundle): [%s]",
+		     browserSourcePath.c_str());
 #endif
 		std::string obs_locale = obs_get_locale();
 		std::string accepted_languages;

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -398,8 +398,17 @@ static void BrowserInit(obs_data_t *settings_obs)
 		std::string binPath = getExecutablePath();
 		binPath = binPath.substr(0,
 					 binPath.size() - strlen("/bin/obs64"));
+		std::string browserSourcePath = binPath;
 		binPath += "/Frameworks/Chromium Embedded Framework.framework";
 		CefString(&settings.framework_dir_path) = binPath;
+		
+		// Set the browser-source-path. Streamlabs desktop (if not run within an app)
+		// will not spin up all the helper apps but at least we will not crash.
+		// Streamlabs desktop.app and OBS.app backend will work properly with browser
+		// sources because they can both spin up the helper processes.
+		browserSourcePath += "/Frameworks/obs64 Helper.app/Contents/MacOS/obs64 Helper";
+		CefString(&settings.browser_subprocess_path) = browserSourcePath;
+		blog(LOG_INFO, "Set browser_subprocess_path for obs64 (app bundle): [%s]", browserSourcePath.c_str());
 #endif
 		std::string obs_locale = obs_get_locale();
 		std::string accepted_languages;


### PR DESCRIPTION
# Motivation for this change:
* fix OBS.app to not crash because we renamed OBS Helper -> obs64 Helper
* fix Streamlabs Desktop to not crash when its run outside of an app bundle. However, they will appear blank because CEF does not spin up the other helpers. But much better then before and we will add a helpful log so devs can get more info if they desire
* maintain legacy behavior where Browser Source can properly spin up obs64 Helpers (GPU / Renderer, etc) when inside of an app bundle

# How Was this Tested?
Locally, I copied over `obs-browser.plugin` into desktop, ran `yarn package:mac` and verified Browser sources still work in the release artifact:
![image](https://github.com/user-attachments/assets/9f301d46-17bb-4702-84ad-09eb7ddb7e4a)

Also, verified when OBS.app is run Browser source works. When Streamlabs desktop is launched from `yarn start` it doesn't crash and at least displays empty browser sources (cause its not run from an app bundle). But at least it doesnt crash due to obs64 version mismatch spam allowing me to troubleshoot other things when I import another user `SceneCollection`
