### PR TITLE
Remove Qt::Widgets dependency

### DIFF
--- a/cmake/os-macos.cmake
+++ b/cmake/os-macos.cmake
@@ -9,7 +9,8 @@ if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3)
   target_compile_options(obs-browser PRIVATE -Wno-error=unqualified-std-cast-call)
 endif()
 
-target_link_libraries(obs-browser PRIVATE Qt::Widgets CEF::Wrapper "$<LINK_LIBRARY:FRAMEWORK,CoreFoundation.framework>"
+# Streamlabs removed Qt::Widgets. Our obs-browser does not use Qt framework
+target_link_libraries(obs-browser PRIVATE CEF::Wrapper "$<LINK_LIBRARY:FRAMEWORK,CoreFoundation.framework>"
                                           "$<LINK_LIBRARY:FRAMEWORK,AppKit.framework>")
 
 set(helper_basename browser-helper)


### PR DESCRIPTION
# Motivation for change
Removing Qt6 dependency that I inadvertantly merged from obs-30.2. Adding comment we do not need to enable Qt::Widgets.

Now when I run `otool -L` on the obs-browser.plugin for mac it no longer depends on Qt framework:
```
~/projects/streamlabs/obs-studio/build_macos/UI/RelWithDebInfo/OBS.app/Contents/PlugIns/obs-browser.plugin/Contents/MacOS/obs-browser:
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2575.50.26)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3423.0.0)
	@rpath/libobs.framework/Versions/A/libobs (compatibility version 1.0.0, current version 30.0.0)
	@rpath/obs-frontend-api.dylib (compatibility version 1.0.0, current version 30.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3423.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.178.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```