### PR TITLE
init CEFInitialize on main thread

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -529,7 +529,8 @@ extern "C" EXPORT void obs_browser_initialize(obs_data_t *settings)
 		BrowserInit(settings);
 #else
 #if defined(__APPLE__)
-		BrowserInit(settings); // invoke CEFInitialize on main thread for Streamlabs
+		BrowserInit(
+			settings); // invoke CEFInitialize on main thread for Streamlabs
 #endif
 		auto binded_fn = bind(BrowserManagerThread, settings);
 		manager_thread = thread(binded_fn);

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -505,6 +505,13 @@ static void BrowserShutdown(void)
 }
 
 #ifndef ENABLE_BROWSER_QT_LOOP
+#if defined(__APPLE__)
+static void BrowserManagerThread(obs_data_t *_)
+{
+	CefRunMessageLoop();
+	BrowserShutdown();
+}
+#else
 static void BrowserManagerThread(obs_data_t *settings)
 {
 	BrowserInit(settings);
@@ -513,12 +520,17 @@ static void BrowserManagerThread(obs_data_t *settings)
 }
 #endif
 
+#endif
+
 extern "C" EXPORT void obs_browser_initialize(obs_data_t *settings)
 {
 	if (!os_atomic_set_bool(&manager_initialized, true)) {
 #ifdef ENABLE_BROWSER_QT_LOOP
 		BrowserInit(settings);
 #else
+#if defined(__APPLE__)
+		BrowserInit(settings); // invoke CEFInitialize on main thread for Streamlabs
+#endif
 		auto binded_fn = bind(BrowserManagerThread, settings);
 		manager_thread = thread(binded_fn);
 #endif


### PR DESCRIPTION
* according to the cef_app.h docs, we must invoke `CEFInitialize` on the main thread. This is a non-issue for OBS because they enable the ENABLE_BROWSER_QT_LOOP which guarantees it's called on main thread (plus they load their scene on the main thread but OSN currently does not)
* This resolves a crash I found on sl-obs31 (fixes backend SLOBS-Qt crash when a browser source is placed in a scene).
* I do not recall seeing this crash on obs-30.2 but it seems prudent to address it anyway (?)