### PR TITLE
remove underscore to fix unused var xcodebuild error

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -506,7 +506,7 @@ static void BrowserShutdown(void)
 
 #ifndef ENABLE_BROWSER_QT_LOOP
 #if defined(__APPLE__)
-static void BrowserManagerThread(obs_data_t *_)
+static void BrowserManagerThread(obs_data_t *)
 {
 	CefRunMessageLoop();
 	BrowserShutdown();


### PR DESCRIPTION
Fix xcode error (I thought I could use underscore but guess that's bad practice so fixing my mistake)

```
2025-08-15T17:08:47.3829810Z ** BUILD FAILED **
2025-08-15T17:08:47.3829810Z 
2025-08-15T17:08:47.3829810Z 
2025-08-15T17:08:47.3829930Z The following build commands failed:
2025-08-15T17:08:47.3830740Z 	CompileC /Users/runner/work/obs-studio/obs-studio/build_macos/build/obs-browser.build/RelWithDebInfo/Objects-normal/arm64/obs-browser-plugin.o /Users/runner/work/obs-studio/obs-studio/plugins/obs-browser/obs-browser-plugin.cpp normal arm64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'obs-browser' from project 'obs-studio')
2025-08-15T17:08:47.3830840Z (1 failure)
2025-08-15T17:08:47.3849160Z ##[error][31m    ✖︎ script execution error.[39m
2025-08-15T17:08:47.3849690Z /Users/runner/work/obs-studio/obs-studio/plugins/obs-browser/obs-browser-plugin.cpp:509:46: error: unused parameter '_' [-Werror,-Wunused-parameter]
2025-08-15T17:08:47.3849780Z static void BrowserManagerThread(obs_data_t *_)
2025-08-15T17:08:47.3849840Z                                              ^
2025-08-15T17:08:47.3849890Z 1 error generated.
```