### PR TITLE
[Mac] Run cef initialize & message loop on main thread

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -507,9 +507,15 @@ static void BrowserShutdown(void)
 #ifndef ENABLE_BROWSER_QT_LOOP
 static void BrowserManagerThread(obs_data_t *settings)
 {
-	BrowserInit(settings);
-	CefRunMessageLoop();
-	BrowserShutdown();
+#ifdef __APPLE__
+	ExecuteSyncTask([&settings]() {
+#endif
+		BrowserInit(settings);
+		CefRunMessageLoop();
+		BrowserShutdown();
+#ifdef __APPLE__
+	});
+#endif
 }
 #endif
 


### PR DESCRIPTION
* fix crash in obs31 branch (once this is merged into that branch)
* resolves warning in obs-30 branch (NSAppearance UI should be invoked on main thread)
* invoke CefInit, Cef message loop, etc on Main thread as indicated by Cef docs

# How was this tested?
Verified browser source appears in slobs.app & locally built Desktop.app