### PR TITLE
fix cef main loop on mac obs-browser

### DIFF
--- a/browser-mac.h
+++ b/browser-mac.h
@@ -44,6 +44,8 @@ bool ExecuteNextBrowserTask();
 void ExecuteTask(MessageTask task);
 void ExecuteSyncTask(MessageTask task);
 void DoCefMessageLoop(int ms);
+void DoCefMessageLoopTimer(float ms);
+void StopCefMessageLoopTimer();
 void Process();
 #if 0  // REMOVE_DUPLICATE
 void QueueBrowserTask(CefRefPtr<CefBrowser> browser, BrowserFunc func);

--- a/browser-mac.mm
+++ b/browser-mac.mm
@@ -26,6 +26,7 @@
 
 std::mutex browserTaskMutex;
 std::deque<Task> browserTasks;
+static NSTimer *cefTimer = nil;
 
 bool ExecuteNextBrowserTask()
 {
@@ -73,8 +74,6 @@ void DoCefMessageLoop(int)
 		CefDoMessageLoopWork();
 	});
 }
-
-static NSTimer *cefTimer = nil;
 
 void DoCefMessageLoopTimer(float ms)
 {

--- a/browser-mac.mm
+++ b/browser-mac.mm
@@ -45,16 +45,26 @@ bool ExecuteNextBrowserTask()
 
 void ExecuteTask(MessageTask task)
 {
-	dispatch_async(dispatch_get_main_queue(), ^{
+	// Protect against exception if already on main thread
+	if ([NSThread isMainThread]) {
 		task();
-	});
+	} else {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			task();
+		});
+	}
 }
 
 void ExecuteSyncTask(MessageTask task)
 {
-	dispatch_sync(dispatch_get_main_queue(), ^{
+	// Protect against exception if already on main thread
+	if ([NSThread isMainThread]) {
 		task();
-	});
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), ^{
+			task();
+		});
+	}
 }
 
 void DoCefMessageLoop(int)
@@ -62,6 +72,24 @@ void DoCefMessageLoop(int)
 	dispatch_async(dispatch_get_main_queue(), ^{
 		CefDoMessageLoopWork();
 	});
+}
+
+static NSTimer *cefTimer = nil;
+
+void DoCefMessageLoopTimer(float ms)
+{
+	cefTimer = [NSTimer
+		scheduledTimerWithTimeInterval:ms
+				       repeats:YES
+					 block:^(NSTimer *) {
+						 CefDoMessageLoopWork();
+					 }];
+}
+
+void StopCefMessageLoopTimer()
+{
+	[cefTimer invalidate];
+	cefTimer = nil;
 }
 
 void Process()

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -333,7 +333,8 @@ static obs_data_array_t *browser_source_get_messages(void *data)
 			messages = obs_data_array_create();
 			for (const auto &message : bs->messagesToApp) {
 				obs_data_t *msg_data = obs_data_create();
-				obs_data_set_string(msg_data, "message", message.c_str());
+				obs_data_set_string(msg_data, "message",
+						    message.c_str());
 				obs_data_array_push_back(messages, msg_data);
 				obs_data_release(msg_data);
 			}
@@ -529,15 +530,9 @@ static void BrowserShutdown(void)
 #ifndef ENABLE_BROWSER_QT_LOOP
 static void BrowserManagerThread(obs_data_t *settings)
 {
-#ifdef __APPLE__
-	ExecuteSyncTask([&settings]() {
-#endif
-		BrowserInit(settings);
-		CefRunMessageLoop();
-		BrowserShutdown();
-#ifdef __APPLE__
-	});
-#endif
+	BrowserInit(settings);
+	CefRunMessageLoop();
+	BrowserShutdown();
 }
 #endif
 
@@ -546,6 +541,12 @@ extern "C" EXPORT void obs_browser_initialize(obs_data_t *settings)
 	if (!os_atomic_set_bool(&manager_initialized, true)) {
 #ifdef ENABLE_BROWSER_QT_LOOP
 		BrowserInit(settings);
+#elif __APPLE__
+
+		ExecuteTask([&settings]() {
+			BrowserInit(settings);
+			DoCefMessageLoopTimer(0.01f); // Do not block the main queue so we avoid calling CefRunMessageLoop()
+		});
 #else
 		auto binded_fn = bind(BrowserManagerThread, settings);
 		manager_thread = thread(binded_fn);
@@ -956,6 +957,11 @@ void obs_module_unload(void)
 {
 #ifdef USE_UI_LOOP
 	BrowserShutdown();
+#elif __APPLE__
+	ExecuteSyncTask([]() {
+		StopCefMessageLoopTimer();
+		BrowserShutdown();
+	});
 #else
 	if (manager_thread.joinable()) {
 		while (!QueueCEFTask([]() { CefQuitMessageLoop(); }))


### PR DESCRIPTION
Making a correction to my previous commit c404f38 which actually breaks SLD because it can block main queue. Reworking this code to avoid calling `CefRunMessageLoop` on main loop because that will block main.
* revert change to `BrowserManagerThread` (APPLE does not need to spin up this thread, CEF runs on main loop)
* Update `ExecuteTask()` and `ExecuteSyncTask()` so these functions can be invoked from main thread if desired w/o throwing an exception (w/o this change you'll crash if you run OBS.app directly because this frontend runs everything from main thread)
* Invoke `CefDoMessageLoopWork` to handle CEF messages on main thread which is non-blocking