### PR TITLE
Harden browser source against GPU-process loss + OnAcceleratedPaint teardown race

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -105,6 +105,10 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 		}
 	}
 
+	/* Survive transient GPU-process loss (e.g. driver TDR) by relaunching it
+	 * instead of escalating to Chromium's fatal "GPU process isn't usable" abort. */
+	command_line->AppendSwitch("disable-gpu-process-crash-limit");
+
 	if (command_line->HasSwitch("disable-features")) {
 		// Don't override existing, as this can break OSR
 		std::string disableFeatures = command_line->GetSwitchValue("disable-features");

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -458,6 +458,13 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType t
 
 	obs_enter_graphics();
 
+	/* Re-check under the lock: Destroy() sets `destroying` and frees the textures
+	 * (under this same lock) on another thread after the early valid() check. */
+	if (!valid()) {
+		obs_leave_graphics();
+		return;
+	}
+
 	if (bs->texture) {
 #ifdef _WIN32
 		//gs_texture_release_sync(bs->texture, 0);


### PR DESCRIPTION
## Summary

Two changes that harden hardware-accelerated browser sources against the libcef crash spike seen on Streamlabs Desktop 1.21.x (crash thread `BrowserManagerThread`, "useless" libcef stacks):

1. **`--disable-gpu-process-crash-limit`** (primary) — survive transient GPU-process loss instead of fatally aborting.
2. **Re-check validity under the graphics lock in `OnAcceleratedPaint`** (secondary hardening) — close a teardown TOCTOU window.

## Root cause (common to the reported crashes)

Both Sentry-reported crashes — the `OnAcceleratedPaint` one and a second "device removed" one — share this line:

```
gpu_data_manager_impl_private.cc:454: GPU process isn't usable. Goodbye.
```

That is Chromium's `GpuDataManagerImplPrivate::FallBackToNextGpuMode()` → `IntentionallyCrashBrowserForUnusableGpuProcess()`: a **deliberate FATAL** once CEF's GPU process has crashed past its limit (~3×) with no remaining fallback mode. The "useless" stack is Chromium intentionally aborting; the real trigger is **CEF's GPU process dying**, correlated in OBS logs with a host **D3D11 device removal / TDR**:

```
gs_texture_open_nt_shared (D3D11): Failed to open shared 2D texture (887A0005)   ; DXGI_ERROR_DEVICE_REMOVED
Device Remove/Reset!  Rebuilding all assets...
Failed to rebuild shared texture: 0x80070057                                     ; E_INVALIDARG
obs-nvenc: ... NV_ENC_ERR_INVALID_DEVICE
```

## Change 1 — `--disable-gpu-process-crash-limit` (primary)

`BrowserApp::OnBeforeCommandLineProcessing` set no GPU-process-resilience switches. With this flag, a transient GPU reset no longer escalates to the fatal abort — CEF keeps relaunching its GPU process across resets. The **GPU watchdog is left intact**, so a *genuinely hung* GPU process is still detected and killed/relaunched. Trade-off: on a *permanently* dead GPU, Chromium will relaunch in a loop (brief repeated glitches) rather than firing one clean fatal — preferable to a crash that drops a live stream.

## Change 2 — re-check validity under the graphics lock (secondary)

`OnAcceleratedPaint` (CEF UI thread) checked `valid()` once, before taking the graphics lock; `BrowserSource::Destroy()` sets `destroying` and frees textures (under that same lock) from another thread during dual-output churn. The early check can pass and the source begin tearing down before the lock is acquired. Re-checking under the lock closes that window. This is real hardening but, given the root cause above, **secondary** — it does not address GPU-process death.

## Why there's nothing to pull from upstream

`OnAcceleratedPaint` is byte-identical to `obsproject/obs-browser@master`; obs-browser registers no libobs device-loss callback and sets no GPU-process-resilience flags. Upstream's only related history (#333) traded the `obs_enter_graphics()`-on-CEF-thread *deadlock* for async destroy — which is what opened the teardown window — and never closed it.

## Verification

- Combined tree builds clean (`cmake --build build_x64 --target obs-browser` → exit 0).
- Flag build deployed to a local runtime for forced-TDR validation (Device-Manager GPU disable/enable loop): expected behavior is OBS surviving repeated resets with no "Goodbye" fatal.
- Guard: crash class reproduced locally and symbolicated to `OnAcceleratedPaint` with a matching `obs-browser.pdb`.
- **Honest caveats:** the GPU-loss crash is environmental (real TDR), so the flag's ultimate proof is field crash telemetry; the teardown race is rare and not A/B-validated.

## Scope

`browser-app.cpp` (one switch) + `browser-client.cpp` (one re-check). No behavior change on the happy path.
